### PR TITLE
Estándar de código

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,14 @@ jobs:
       - name: Set Laravel application key
         run: php artisan key:generate
 
-      - name: Tests
-        run: php artisan test
+      - name: PHP Insights
+        run: vendor/bin/rector --dry-run
+
+      - name: Static analysis
+        run: vendor/bin/phpstan analyse --no-progress --no-interaction --ansi
 
       - name: PHP Insights
         run: php artisan insights --no-interaction --ansi --format=github-action
 
-      - name: Static analysis
-        run: vendor/bin/phpstan analyse --no-progress --no-interaction --ansi
+      - name: Tests
+        run: php artisan test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,20 @@ Este proyecto usa [PHPStan][] a través de [Larastan][].
 php vendor/bin/phpstan analyse -v
 ```
 
+### `rector/rector`
+
+[Rector][] permite automatizar la modificación de código, se agregó al proyecto para hacer las modificaciones
+automáticas de PHP 7.3 a PHP 7.4. No está agregado a proceso de CI porque no es necesaria su ejecución continua.
+
+```shell
+php vendor/bin/rector process --dry-run
+```
+### Ejecución de todas las herramientas
+```shell
+composer dev:build
+```
+
+
 ## Otras herramientas
 
 ### Simulación de GitHub Actions
@@ -70,15 +84,6 @@ Con la herramienta [nektos/act][] se puede simular todos los flujos de trabajo e
 
 ```shell
 act -P ubuntu-latest=shivammathur/node:latest
-```
-
-## `rector/rector`
-
-[Rector][] permite automatizar la modificación de código, se agregó al proyecto para hacer las modificaciones
-automáticas de PHP 7.3 a PHP 7.4. No está agregado a proceso de CI porque no es necesaria su ejecución continua.
-
-```shell
-php vendor/bin/rector process --dry-run
 ```
 
 [PHPInsights]: https://phpinsights.com/

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -10,7 +10,7 @@ class Kernel extends ConsoleKernel
     /**
      * The Artisan commands provided by your application.
      *
-     * @var array
+     * @var array<string>
      */
     protected $commands = [
         //
@@ -19,7 +19,6 @@ class Kernel extends ConsoleKernel
     /**
      * Define the application's command schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
      * @return void
      */
     protected function schedule(Schedule $schedule)
@@ -34,7 +33,7 @@ class Kernel extends ConsoleKernel
      */
     protected function commands()
     {
-        $this->load(__DIR__.'/Commands');
+        $this->load(__DIR__ . '/Commands');
 
         require base_path('routes/console.php');
     }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -10,7 +10,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the exception types that are not reported.
      *
-     * @var array
+     * @var array<string>
      */
     protected $dontReport = [
         //
@@ -19,7 +19,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var array<string>
      */
     protected $dontFlash = [
         'current_password',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -11,7 +11,7 @@ class Kernel extends HttpKernel
      *
      * These middleware are run during every request to your application.
      *
-     * @var array
+     * @var array<class-string>
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
     /**
      * The application's route middleware groups.
      *
-     * @var array
+     * @var array<string,array<string>>
      */
     protected $middlewareGroups = [
         'web' => [
@@ -51,7 +51,7 @@ class Kernel extends HttpKernel
      *
      * These middleware may be assigned to groups or used individually.
      *
-     * @var array
+     * @var array<string,string>
      */
     protected $routeMiddleware = [
         'auth' => \App\Http\Middleware\Authenticate::class,

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -9,7 +9,7 @@ class EncryptCookies extends Middleware
     /**
      * The names of the cookies that should not be encrypted.
      *
-     * @var array
+     * @var array<string>
      */
     protected $except = [
 

--- a/app/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -9,7 +9,7 @@ class PreventRequestsDuringMaintenance extends Middleware
     /**
      * The URIs that should be reachable while maintenance mode is enabled.
      *
-     * @var array
+     * @var array<string>
      */
     protected $except = [
 

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -12,8 +12,6 @@ class RedirectIfAuthenticated
     /**
      * Handle an incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
      * @param  string|null  ...$guards
      * @return mixed
      */

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -9,7 +9,7 @@ class TrimStrings extends Middleware
     /**
      * The names of the attributes that should not be trimmed.
      *
-     * @var array
+     * @var array<string>
      */
     protected $except = [
         'current_password',

--- a/app/Http/Middleware/TrustHosts.php
+++ b/app/Http/Middleware/TrustHosts.php
@@ -9,7 +9,7 @@ class TrustHosts extends Middleware
     /**
      * Get the host patterns that should be trusted.
      *
-     * @return array
+     * @return array<?string>
      */
     public function hosts()
     {

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -10,7 +10,7 @@ class TrustProxies extends Middleware
     /**
      * The trusted proxies for this application.
      *
-     * @var array|string|null
+     * @var array<string>|string|null
      */
     protected $proxies;
 

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -9,7 +9,7 @@ class VerifyCsrfToken extends Middleware
     /**
      * The URIs that should be excluded from CSRF verification.
      *
-     * @var array
+     * @var array<string>
      */
     protected $except = [
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,9 @@ use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens;
+    use HasFactory;
+    use Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -25,7 +27,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be hidden for serialization.
      *
-     * @var array
+     * @var array<string>
      */
     protected $hidden = [
         'password',
@@ -35,7 +37,7 @@ class User extends Authenticatable
     /**
      * The attributes that should be cast.
      *
-     * @var array
+     * @var array<string,string>
      */
     protected $casts = [
         'email_verified_at' => 'datetime',

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -9,7 +9,7 @@ class AuthServiceProvider extends ServiceProvider
     /**
      * The policy mappings for the application.
      *
-     * @var array
+     * @var array<string,string>
      */
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,7 +11,7 @@ class EventServiceProvider extends ServiceProvider
     /**
      * The event listener mappings for the application.
      *
-     * @var array
+     * @var array<class-string, array<class-string>>
      */
     protected $listen = [
         Registered::class => [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "nunomaduro/collision": "^5.0",
         "nunomaduro/larastan": "^0.7.12",
         "nunomaduro/phpinsights": "^2.0",
-        "phpunit/phpunit": "^9.3.3"
+        "phpunit/phpunit": "^9.3.3",
+        "rector/rector": "^0.11.56",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {
         "psr-4": {
@@ -47,6 +49,20 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "dev:phpstan": "@php vendor/bin/phpstan analyze",
+        "dev:phpinsights-fix": "@php artisan insights --fix",
+        "dev:phpinsights": "@php artisan insights",
+        "dev:rector-fix": "@php vendor/bin/rector process",
+        "dev:rector": "@php vendor/bin/rector process --dry-run",
+        "dev:test": "@php artisan test",
+        "dev:build": [
+            "@dev:rector-fix",
+            "@dev:rector",
+            "@dev:phpstan",
+            "@dev:phpinsights-fix",
+            "@dev:phpinsights",
+            "@dev:test"
         ]
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8b18904e046ad988e921b39116e2d89",
+    "content-hash": "fb6db65f704d5198dd5f9802223ec025",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1584,16 +1584,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.3.4",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "437e7a1c50044b92773b361af77620efb76fff59"
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437e7a1c50044b92773b361af77620efb76fff59",
-                "reference": "437e7a1c50044b92773b361af77620efb76fff59",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/fd4380d6fc37626e2f799f29d91195040137eba9",
+                "reference": "fd4380d6fc37626e2f799f29d91195040137eba9",
                 "shasum": ""
             },
             "require": {
@@ -1609,7 +1609,7 @@
                 "elasticsearch/elasticsearch": "^7",
                 "graylog2/gelf-php": "^1.4.2",
                 "mongodb/mongodb": "^1.8",
-                "php-amqplib/php-amqplib": "~2.4",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.3",
                 "phpspec/prophecy": "^1.6.1",
                 "phpstan/phpstan": "^0.12.91",
@@ -1667,7 +1667,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.3.4"
+                "source": "https://github.com/Seldaek/monolog/tree/2.3.5"
             },
             "funding": [
                 {
@@ -1679,7 +1679,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-15T11:27:21+00:00"
+            "time": "2021-10-01T21:08:31+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -6109,16 +6109,16 @@
         },
         {
             "name": "facade/ignition",
-            "version": "2.13.1",
+            "version": "2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition.git",
-                "reference": "e3f49bef7b4165fa4b8a9dc579e7b63fa06aef78"
+                "reference": "c6126e291bd44ad3fe482537a145fc70e3320598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition/zipball/e3f49bef7b4165fa4b8a9dc579e7b63fa06aef78",
-                "reference": "e3f49bef7b4165fa4b8a9dc579e7b63fa06aef78",
+                "url": "https://api.github.com/repos/facade/ignition/zipball/c6126e291bd44ad3fe482537a145fc70e3320598",
+                "reference": "c6126e291bd44ad3fe482537a145fc70e3320598",
                 "shasum": ""
             },
             "require": {
@@ -6181,7 +6181,7 @@
                 "issues": "https://github.com/facade/ignition/issues",
                 "source": "https://github.com/facade/ignition"
             },
-            "time": "2021-09-13T13:01:30+00:00"
+            "time": "2021-10-01T12:58:45+00:00"
         },
         {
             "name": "facade/ignition-contracts",
@@ -6584,16 +6584,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.10.2",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "0b9ddae87b5867e0ca3a68f3b645079054c7ace3"
+                "reference": "5c91d33949e43500dc1d49abc5d7c2ffb6c96f44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/0b9ddae87b5867e0ca3a68f3b645079054c7ace3",
-                "reference": "0b9ddae87b5867e0ca3a68f3b645079054c7ace3",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/5c91d33949e43500dc1d49abc5d7c2ffb6c96f44",
+                "reference": "5c91d33949e43500dc1d49abc5d7c2ffb6c96f44",
                 "shasum": ""
             },
             "require": {
@@ -6640,7 +6640,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2021-09-28T15:33:02+00:00"
+            "time": "2021-10-01T13:32:17+00:00"
         },
         {
             "name": "league/container",
@@ -8282,6 +8282,65 @@
                 "source": "https://github.com/reactphp/promise/tree/v2.8.0"
             },
             "time": "2020-05-12T15:16:56+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "0.11.56",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "9f601b77550dbfa6e096028f8aaecf7021c1bc46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/9f601b77550dbfa6e096028f8aaecf7021c1bc46",
+                "reference": "9f601b77550dbfa6e096028f8aaecf7021c1bc46",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0",
+                "phpstan/phpstan": "0.12.99"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<=0.5.3",
+                "phpstan/phpstan": "<=0.12.82",
+                "rector/rector-cakephp": "*",
+                "rector/rector-doctrine": "*",
+                "rector/rector-nette": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-prefixed": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.11-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Prefixed and PHP 7.1 downgraded version of rector/rector",
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/0.11.56"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-09-28T19:06:03+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -18,7 +18,7 @@ class UserFactory extends Factory
     /**
      * Define the model's default state.
      *
-     * @return array
+     * @return array<string,mixed>
      */
     public function definition()
     {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,27 @@
+<ruleset name="PHP_CodeSniffer">
+    <description>The coding standard for our project.</description>
+    <rule ref="PSR12"/>
+
+    <file>app</file>
+    <file>bootstrap</file>
+    <file>config</file>
+    <file>database</file>
+    <file>resources</file>
+    <file>routes</file>
+    <file>tests</file>
+    <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+        <exclude-pattern>tests/*.php</exclude-pattern>
+    </rule>
+    <exclude-pattern>bootstrap/cache/*</exclude-pattern>
+    <exclude-pattern>bootstrap/autoload.php</exclude-pattern>
+    <exclude-pattern>database/migrations/*.php</exclude-pattern>
+    <exclude-pattern>*.blade.php</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
+    <exclude-pattern>vendor</exclude-pattern>
+    <exclude-pattern>resources</exclude-pattern>
+    <exclude-pattern>storage/</exclude-pattern>
+    <exclude-pattern>node_modules/</exclude-pattern>
+
+    <!-- Show progression -->
+    <arg value="p"/>
+</ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,8 @@ includes:
     - ./vendor/nunomaduro/larastan/extension.neon
 
 parameters:
-    level: 5
+    level: 8
     paths:
         - app
+        - database
+        - tests

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Core\Configuration\Option;
+use Rector\Set\ValueObject\SetList;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    // get parameters
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/app/',
+        __DIR__ . '/bootstrap/',
+        __DIR__ . '/config/',
+        __DIR__ . '/database/',
+        __DIR__ . '/public/',
+        __DIR__ . '/routes/',
+        __DIR__ . '/tests/',
+    ]);
+    $parameters->set(Option::SKIP, [
+        'config/insights.php',
+    ]);
+
+    // Define what rule sets will be applied
+    $containerConfigurator->import(SetList::PHP_80);
+
+    // get services (needed for register a single rule)
+    // $services = $containerConfigurator->services();
+
+    // register a single rule
+    // $services->set(TypedPropertyRector::class);
+};


### PR DESCRIPTION
- Se cambió el archivo de configuración de phpstan a nivel: 8 con sus respectivos fixes para el proyecto.
- Se agregó phpcs para sniffing de código.
- Se agregó rector configurado para php8.0
- Se agregaron todos los comandos al `composer.json` para poder correr todas las herramientos en un solo comando: `composer dev:build`
- Se agregó la documentación de estos cambios en el `CONTRIBUTING.MD`
- Se agregó la herramienta faltante al workflow: rector